### PR TITLE
Fix status cleanup configuration error

### DIFF
--- a/app/controllers/statuses_cleanup_controller.rb
+++ b/app/controllers/statuses_cleanup_controller.rb
@@ -30,7 +30,7 @@ class StatusesCleanupController < ApplicationController
   end
 
   def resource_params
-    params.require(:account_statuses_cleanup_policy).permit(:enabled, :min_status_age, :keep_direct, :keep_pinned, :keep_polls, :keep_media, :keep_self_fav, keep_self_reaction, :keep_self_bookmark, :min_favs, :min_reblogs)
+    params.require(:account_statuses_cleanup_policy).permit(:enabled, :min_status_age, :keep_direct, :keep_pinned, :keep_polls, :keep_media, :keep_self_fav, :keep_self_reaction, :keep_self_bookmark, :min_favs, :min_reblogs)
   end
 
   def set_body_classes


### PR DESCRIPTION
自動削除設定時に以下エラーとなっていたため修正しました

```
[07b95eca-3ee2-4b13-8a9b-baa28d87f297] NameError (undefined local variable or method `keep_self_reaction' for #<StatusesCleanupController:0x000000013ddc80>):
[07b95eca-3ee2-4b13-8a9b-baa28d87f297]
[07b95eca-3ee2-4b13-8a9b-baa28d87f297] app/controllers/statuses_cleanup_controller.rb:33:in `resource_params'
[07b95eca-3ee2-4b13-8a9b-baa28d87f297] app/controllers/statuses_cleanup_controller.rb:13:in `update'
[07b95eca-3ee2-4b13-8a9b-baa28d87f297] app/controllers/concerns/localized.rb:11:in `set_locale'
[07b95eca-3ee2-4b13-8a9b-baa28d87f297] lib/mastodon/rack_middleware.rb:9:in `call'
```